### PR TITLE
fix: use weak pointer for player reference in SpawnLevel

### DIFF
--- a/Source/SideRunner/SpawnLevel.h
+++ b/Source/SideRunner/SpawnLevel.h
@@ -16,6 +16,7 @@ public:
 
 protected:
     virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 public:
     virtual void Tick(float DeltaTime) override;
@@ -30,7 +31,8 @@ public:
     void DestroyOldestLevel(); // Marked as UFUNCTION to expose it to the engine
 
 protected:
-    APawn* Player;
+    /** Weak reference to player pawn - handles pawn respawn/death correctly */
+    TWeakObjectPtr<APawn> PlayerWeakPtr;
 
     UPROPERTY(EditAnywhere)
     TSubclassOf<ABaseLevel> Level1;
@@ -62,6 +64,8 @@ private:
 
     void SpawnInitialLevels();
     void DelayedDestroyOldestLevel();
+    void TryAcquirePlayerPawn();
 
-    FTimerHandle DestroyTimerHandle; // Add a timer handle for the destruction delay
+    /** Array of timer handles for pending destroy operations */
+    TArray<FTimerHandle> PendingDestroyTimers;
 };


### PR DESCRIPTION
- Replace raw APawn* with TWeakObjectPtr<APawn> to handle player death/respawn
- Re-acquire player reference in Tick() and OnOverlapBegin() if stale
- Use TArray<FTimerHandle> for pending destroy operations instead of single handle
- Add EndPlay() cleanup to clear timers and unbind delegates
- Validate LevelList entries and remove stale references in SpawnLevel()
- Unbind delegates from levels before destruction to prevent stale callbacks

Fixes issue where level spawning stopped after player death because the pointer to the destroyed pawn became stale.