### PR TITLE
feat: Fix state management issues for endless runner

### DIFF
--- a/Source/SideRunner/RunnerCharacter.cpp
+++ b/Source/SideRunner/RunnerCharacter.cpp
@@ -925,7 +925,7 @@ void ARunnerCharacter::RespawnPlayer()
     }
 
     // Update respawn location in game instance for score tracking
-    CachedGameInstance = Cast<USideRunnerGameInstance>(UGameplayStatics::GetGameInstance(this));
+    // Use cached instance from BeginPlay (avoid redundant casting per performance comment in header)
     if (IsValid(CachedGameInstance))
     {
         CachedGameInstance->SetRespawnLocation(RespawnLocation);

--- a/Source/SideRunner/RunnerCharacter.cpp
+++ b/Source/SideRunner/RunnerCharacter.cpp
@@ -13,6 +13,7 @@
 #include "PlayerHealthComponent.h"
 #include "SideRunnerGameInstance.h"
 #include "GameFramework/PlayerStart.h"
+#include "SpawnLevel.h" // For ResetLevelsForRespawn on respawn
 #include "SideRunner.h" // Custom log categories
 
 // CRITICAL FIX: Comprehensive validation macro for HealthComponent access
@@ -877,49 +878,58 @@ void ARunnerCharacter::RespawnPlayer()
     // Reset animation state
     SetCharacterState(ECharacterState::Idle);
 
-    // CRITICAL FIX: Get respawn location from game instance (or use player start)
+    // CRITICAL FIX: Always use PlayerStart for respawn - it's the known valid location with ground
     FVector RespawnLocation = FVector::ZeroVector;
     FRotator RespawnRotation = FRotator::ZeroRotator;
 
-    // Try to get saved respawn location
-    CachedGameInstance = Cast<USideRunnerGameInstance>(GetGameInstance());
-    if (IsValid(CachedGameInstance))
-    {
-        RespawnLocation = CachedGameInstance->GetRespawnLocation();
-    }
+    // Find PlayerStart for respawn location (known to have valid geometry)
+    TArray<AActor*> PlayerStarts;
+    UGameplayStatics::GetAllActorsOfClass(World, APlayerStart::StaticClass(), PlayerStarts);
 
-    // If no saved location, find PlayerStart
-    if (RespawnLocation.IsZero())
+    if (PlayerStarts.Num() > 0)
     {
-        TArray<AActor*> PlayerStarts;
-        UGameplayStatics::GetAllActorsOfClass(World, APlayerStart::StaticClass(), PlayerStarts);
-
-        if (PlayerStarts.Num() > 0)
+        APlayerStart* PlayerStart = Cast<APlayerStart>(PlayerStarts[0]);
+        if (PlayerStart)
         {
-            APlayerStart* PlayerStart = Cast<APlayerStart>(PlayerStarts[0]);
-            if (PlayerStart)
-            {
-                RespawnLocation = PlayerStart->GetActorLocation();
-                RespawnRotation = PlayerStart->GetActorRotation();
-                UE_LOG(LogSideRunner, Log, TEXT("Using PlayerStart location: %s"), *RespawnLocation.ToString());
-            }
-        }
-        else
-        {
-            // Fallback to origin if no PlayerStart found
-            RespawnLocation = RunnerCharacterConstants::FALLBACK_RESPAWN_LOCATION;
-            UE_LOG(LogSideRunner, Warning, TEXT("No PlayerStart found - using fallback location"));
+            RespawnLocation = PlayerStart->GetActorLocation();
+            RespawnRotation = PlayerStart->GetActorRotation();
+            UE_LOG(LogSideRunner, Log, TEXT("Using PlayerStart location for respawn: %s"), *RespawnLocation.ToString());
         }
     }
+    else
+    {
+        // Fallback to origin if no PlayerStart found
+        RespawnLocation = RunnerCharacterConstants::FALLBACK_RESPAWN_LOCATION;
+        UE_LOG(LogSideRunner, Warning, TEXT("No PlayerStart found - using fallback location"));
+    }
 
-    // Teleport player to respawn location
+    // Teleport player to respawn location FIRST (before level reset)
     SetActorLocation(RespawnLocation, false, nullptr, ETeleportType::ResetPhysics);
     SetActorRotation(RespawnRotation);
 
-    // Reset velocity
+    // Reset velocity immediately
     if (UCharacterMovementComponent* MovementComponent = GetCharacterMovement())
     {
         MovementComponent->Velocity = FVector::ZeroVector;
+    }
+
+    // CRITICAL FIX: Reset all level spawners to create fresh levels at player position
+    TArray<AActor*> SpawnLevelActors;
+    UGameplayStatics::GetAllActorsOfClass(World, ASpawnLevel::StaticClass(), SpawnLevelActors);
+    for (AActor* Actor : SpawnLevelActors)
+    {
+        if (ASpawnLevel* SpawnLevelActor = Cast<ASpawnLevel>(Actor))
+        {
+            SpawnLevelActor->ResetLevelsForRespawn();
+        }
+    }
+
+    // Update respawn location in game instance for score tracking
+    CachedGameInstance = Cast<USideRunnerGameInstance>(UGameplayStatics::GetGameInstance(this));
+    if (IsValid(CachedGameInstance))
+    {
+        CachedGameInstance->SetRespawnLocation(RespawnLocation);
+        CachedGameInstance->InitializeDistanceTracking(RespawnLocation.X);
     }
 
     UE_LOG(LogSideRunner, Log, TEXT("Player respawned at: %s"), *RespawnLocation.ToString());

--- a/Source/SideRunner/SpawnLevel.cpp
+++ b/Source/SideRunner/SpawnLevel.cpp
@@ -216,6 +216,13 @@ void ASpawnLevel::DestroyOldestLevel()
 
 void ASpawnLevel::ResetLevelsForRespawn()
 {
+    // Guard clause: Ensure we have a valid world context
+    if (!GetWorld())
+    {
+        UE_LOG(LogSideRunner, Warning, TEXT("ResetLevelsForRespawn: Called with no world, aborting."));
+        return;
+    }
+
     UE_LOG(LogSideRunner, Log, TEXT("ResetLevelsForRespawn: Clearing all levels for player respawn"));
 
     // Clear all pending destroy timers to prevent callbacks on destroyed levels

--- a/Source/SideRunner/SpawnLevel.cpp
+++ b/Source/SideRunner/SpawnLevel.cpp
@@ -214,6 +214,47 @@ void ASpawnLevel::DestroyOldestLevel()
     }
 }
 
+void ASpawnLevel::ResetLevelsForRespawn()
+{
+    UE_LOG(LogSideRunner, Log, TEXT("ResetLevelsForRespawn: Clearing all levels for player respawn"));
+
+    // Clear all pending destroy timers to prevent callbacks on destroyed levels
+    for (FTimerHandle& TimerHandle : PendingDestroyTimers)
+    {
+        if (GetWorld())
+        {
+            GetWorld()->GetTimerManager().ClearTimer(TimerHandle);
+        }
+    }
+    PendingDestroyTimers.Empty();
+
+    // Destroy all existing levels and unbind delegates
+    for (ABaseLevel* Level : LevelList)
+    {
+        if (IsValid(Level))
+        {
+            if (UBoxComponent* Trigger = Level->GetTrigger())
+            {
+                Trigger->OnComponentBeginOverlap.RemoveDynamic(this, &ASpawnLevel::OnOverlapBegin);
+            }
+            Level->Destroy();
+        }
+    }
+    LevelList.Empty();
+
+    // Re-acquire player reference and spawn fresh levels
+    TryAcquirePlayerPawn();
+    if (PlayerWeakPtr.IsValid())
+    {
+        SpawnInitialLevels();
+        UE_LOG(LogSideRunner, Log, TEXT("ResetLevelsForRespawn: Spawned %d fresh levels"), LevelList.Num());
+    }
+    else
+    {
+        UE_LOG(LogSideRunner, Warning, TEXT("ResetLevelsForRespawn: Player not found, levels will spawn when player becomes available"));
+    }
+}
+
 void ASpawnLevel::OnOverlapBegin(UPrimitiveComponent* OverlappedComp, AActor* OtherActor,
     UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep,
     const FHitResult& SweepResult)

--- a/Source/SideRunner/SpawnLevel.h
+++ b/Source/SideRunner/SpawnLevel.h
@@ -30,6 +30,10 @@ public:
     UFUNCTION()
     void DestroyOldestLevel(); // Marked as UFUNCTION to expose it to the engine
 
+    /** Reset all spawned levels and respawn fresh levels around player position */
+    UFUNCTION(BlueprintCallable, Category="Level Management")
+    void ResetLevelsForRespawn();
+
 protected:
     /** Weak reference to player pawn - handles pawn respawn/death correctly */
     TWeakObjectPtr<APawn> PlayerWeakPtr;

--- a/Source/SideRunner/WallSpike.cpp
+++ b/Source/SideRunner/WallSpike.cpp
@@ -338,9 +338,8 @@ void AWallSpike::ResetPositionBehindPlayer(ARunnerCharacter* Player)
 	const FVector PrimaryDir = GetPrimaryDirection();
 	
 	// Position spike behind player (opposite of primary direction)
-	// Use a safe distance that gives player time to react
-	const float DistanceBehind = 1500.0f;
-	const FVector NewLocation = PlayerLocation - (PrimaryDir * DistanceBehind);
+	// Use configurable distance that gives player time to react
+	const FVector NewLocation = PlayerLocation - (PrimaryDir * RespawnDistanceBehind);
 	
 	SetActorLocation(NewLocation);
 	CurrentDirection = PrimaryDir;

--- a/Source/SideRunner/WallSpike.h
+++ b/Source/SideRunner/WallSpike.h
@@ -77,6 +77,10 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Lifetime", meta = (ClampMin = "1.0", ClampMax = "30.0"))
 	float MaxTimeBehindPlayer = 10.0f;
 
+	/** Distance behind player to position WallSpike when player respawns */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Lifetime", meta = (ClampMin = "500.0", ClampMax = "5000.0"))
+	float RespawnDistanceBehind = 1500.0f;
+
 	// PERFORMANCE: Audio properties
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Audio")
 	USoundBase* ChaseStartSound;

--- a/Source/SideRunner/WallSpike.h
+++ b/Source/SideRunner/WallSpike.h
@@ -127,6 +127,7 @@ private:
 	void HandlePlayerOutOfRange();
 	void HandleChaseAudioStart(bool bWasHasTarget);
 	void StopChaseAudio();
+	void ResetPositionBehindPlayer(ARunnerCharacter* Player);
 	
 #if WITH_EDITOR
 	void DrawDebugVisualization();


### PR DESCRIPTION
Fixes three critical bugs:

1. Level Generation: Add ResetLevelsForRespawn() to SpawnLevel
   - Clears all pending destroy timers
   - Destroys existing levels and unbinds delegates
   - Spawns fresh initial levels at player position

2. Respawn Mechanics: Fix RespawnPlayer() in RunnerCharacter
   - Always use PlayerStart location (known valid geometry)
   - Call ResetLevelsForRespawn() to create fresh levels
   - Update GameInstance with new respawn location

3. WallSpike Reset: Add ResetPositionBehindPlayer()
   - Detect player respawn in UpdateTargetPlayer()
   - Reposition WallSpike behind player on respawn
   - Reset chase state flags

Files modified:
- SpawnLevel.h/cpp: Added ResetLevelsForRespawn()
- RunnerCharacter.cpp: Updated respawn flow + include
- WallSpike.h/cpp: Added respawn detection + reset logic