### PR TITLE
fix(wallspike): cancel destruction timer on player respawn

### DIFF
--- a/Source/SideRunner/WallSpike.cpp
+++ b/Source/SideRunner/WallSpike.cpp
@@ -333,6 +333,12 @@ void AWallSpike::ResetPositionBehindPlayer(ARunnerCharacter* Player)
 		return;
 	}
 
+	// Cancel pending destruction timer since player respawned
+	if (UWorld* World = GetWorld())
+	{
+		World->GetTimerManager().ClearTimer(DeathDestroyTimerHandle);
+	}
+
 	// Calculate position behind player based on primary direction
 	const FVector PlayerLocation = Player->GetActorLocation();
 	const FVector PrimaryDir = GetPrimaryDirection();
@@ -559,9 +565,8 @@ void AWallSpike::ApplyInstantDeathToPlayer(ARunnerCharacter* Player, FVector Hit
 		return;
 	}
 
-	// PERFORMANCE: Use lambda with timer for destruction
-	FTimerHandle DestroyTimer;
-	World->GetTimerManager().SetTimer(DestroyTimer, [this]()
+	// Store timer handle so we can cancel it if player respawns
+	World->GetTimerManager().SetTimer(DeathDestroyTimerHandle, [this]()
 	{
 		if (IsValid(this))
 		{

--- a/Source/SideRunner/WallSpike.h
+++ b/Source/SideRunner/WallSpike.h
@@ -117,6 +117,9 @@ private:
 	UPROPERTY()
 	UAudioComponent* ChaseAudioComponent;
 
+	// Timer handle for destruction - stored so it can be canceled on player respawn
+	FTimerHandle DeathDestroyTimerHandle;
+
 	// PERFORMANCE: Core functionality methods
 	FVector GetPrimaryDirection() const;
 	void UpdateTargetPlayer();


### PR DESCRIPTION
WallSpike was being destroyed even after player respawned because the destruction timer handle was stored in a local variable and couldn't be canceled. Now the timer handle is stored as a member variable and explicitly canceled in ResetPositionBehindPlayer() when player respawns.