### PR TITLE
fix(respawn): spawn level platforms at player position on respawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ DerivedDataCache/*
 .gemini/
 gha-creds-*.json
 
+# Backup files
+*.bak
+
 # Claude AI temp files
 .claude/
 

--- a/Source/SideRunner/RunnerCharacter.cpp
+++ b/Source/SideRunner/RunnerCharacter.cpp
@@ -888,15 +888,19 @@ void ARunnerCharacter::RespawnPlayer()
         UE_LOG(LogSideRunner, Warning, TEXT("No PlayerStart found - using fallback location"));
     }
 
-    // Teleport player to respawn location FIRST (before level reset)
+    // RESPAWN FIX: Disable movement BEFORE teleport to prevent falling during level rebuild
+    // This eliminates the race condition where gravity applies between teleport and level spawn
+    UCharacterMovementComponent* MoveComp = GetCharacterMovement();
+    if (MoveComp)
+    {
+        MoveComp->GravityScale = 0.0f;
+        MoveComp->SetMovementMode(MOVE_None);
+        MoveComp->Velocity = FVector::ZeroVector;
+    }
+
+    // Teleport player to respawn location
     SetActorLocation(RespawnLocation, false, nullptr, ETeleportType::ResetPhysics);
     SetActorRotation(RespawnRotation);
-
-    // Reset velocity immediately
-    if (UCharacterMovementComponent* MovementComponent = GetCharacterMovement())
-    {
-        MovementComponent->Velocity = FVector::ZeroVector;
-    }
 
     // CRITICAL FIX: Reset all level spawners to create fresh levels at player position
     TArray<AActor*> SpawnLevelActors;
@@ -907,6 +911,13 @@ void ARunnerCharacter::RespawnPlayer()
         {
             SpawnLevelActor->ResetLevelsForRespawn();
         }
+    }
+
+    // RESPAWN FIX: Restore movement now that levels are spawned beneath the player
+    if (MoveComp)
+    {
+        MoveComp->GravityScale = 2.5f;  // Matches constructor value (line 100)
+        MoveComp->SetMovementMode(MOVE_Walking);
     }
 
     // Update respawn location in game instance for score tracking

--- a/Source/SideRunner/SpawnLevel.cpp
+++ b/Source/SideRunner/SpawnLevel.cpp
@@ -4,11 +4,13 @@
 #include "Engine/World.h"
 #include "Components/BoxComponent.h"
 #include "TimerManager.h"
+#include "Kismet/GameplayStatics.h"
 
 // Sets default values
 ASpawnLevel::ASpawnLevel()
 {
     PrimaryActorTick.bCanEverTick = true;
+    FirstLevelSpawnPosition = FVector(0.0f, 1000.0f, 0.0f);
 }
 
 // Called when the game starts or when spawned
@@ -21,7 +23,9 @@ void ASpawnLevel::BeginPlay()
         PlayerWeakPtr = PC->GetPawn();
         if (PlayerWeakPtr.IsValid())
         {
-            SpawnInitialLevels();
+            // Spawn levels relative to player's Y position (game scrolls along Y axis)
+            FVector PlayerLoc = PlayerWeakPtr->GetActorLocation();
+            SpawnInitialLevels(FVector(0.0f, PlayerLoc.Y, 0.0f));
         }
         else
         {
@@ -58,9 +62,21 @@ void ASpawnLevel::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 void ASpawnLevel::TryAcquirePlayerPawn()
 {
-    if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+    UWorld* World = GetWorld();
+    if (!World)
+    {
+        return;
+    }
+
+    if (APlayerController* PC = World->GetFirstPlayerController())
     {
         PlayerWeakPtr = PC->GetPawn();
+    }
+
+    // Fallback: use GameplayStatics if controller path fails (handles mid-respawn transitions)
+    if (!PlayerWeakPtr.IsValid())
+    {
+        PlayerWeakPtr = UGameplayStatics::GetPlayerPawn(this, 0);
     }
 }
 
@@ -75,15 +91,19 @@ void ASpawnLevel::Tick(float DeltaTime)
         TryAcquirePlayerPawn();
         if (PlayerWeakPtr.IsValid() && LevelList.Num() == 0)
         {
-            SpawnInitialLevels();
+            // Tick recovery: spawn levels at player's current Y position
+            FVector PlayerLoc = PlayerWeakPtr->GetActorLocation();
+            SpawnInitialLevels(FVector(0.0f, PlayerLoc.Y, 0.0f));
         }
     }
 }
 
-void ASpawnLevel::SpawnInitialLevels()
+void ASpawnLevel::SpawnInitialLevels(const FVector& StartPosition)
 {
     if (LevelList.Num() == 0)
     {
+        // Store position so SpawnLevel(true) uses it for the first segment
+        FirstLevelSpawnPosition = StartPosition;
         for (int32 i = 0; i < 4; ++i)
         {
             SpawnLevel(i == 0);
@@ -93,7 +113,7 @@ void ASpawnLevel::SpawnInitialLevels()
 
 void ASpawnLevel::SpawnLevel(bool IsFirst)
 {
-    FVector NewSpawnLocation = FVector(0.0f, 1000.0f, 0.0f);
+    FVector NewSpawnLocation = FirstLevelSpawnPosition;
     FRotator NewSpawnRotation = FRotator(0, 90, 0);
 
     if (!IsFirst && LevelList.Num() > 0)
@@ -249,12 +269,13 @@ void ASpawnLevel::ResetLevelsForRespawn()
     }
     LevelList.Empty();
 
-    // Re-acquire player reference and spawn fresh levels
+    // Re-acquire player reference and spawn fresh levels at player's current position
     TryAcquirePlayerPawn();
     if (PlayerWeakPtr.IsValid())
     {
-        SpawnInitialLevels();
-        UE_LOG(LogSideRunner, Log, TEXT("ResetLevelsForRespawn: Spawned %d fresh levels"), LevelList.Num());
+        FVector PlayerLoc = PlayerWeakPtr->GetActorLocation();
+        SpawnInitialLevels(FVector(0.0f, PlayerLoc.Y, 0.0f));
+        UE_LOG(LogSideRunner, Log, TEXT("ResetLevelsForRespawn: Spawned %d fresh levels at Y=%.1f"), LevelList.Num(), PlayerLoc.Y);
     }
     else
     {

--- a/Source/SideRunner/SpawnLevel.h
+++ b/Source/SideRunner/SpawnLevel.h
@@ -66,9 +66,12 @@ private:
     UPROPERTY()
     TArray<ABaseLevel*> LevelList;
 
-    void SpawnInitialLevels();
+    void SpawnInitialLevels(const FVector& StartPosition = FVector(0.0f, 1000.0f, 0.0f));
     void DelayedDestroyOldestLevel();
     void TryAcquirePlayerPawn();
+
+    /** Cached first-level spawn position - updated on each spawn cycle to match player location */
+    FVector FirstLevelSpawnPosition = FVector(0.0f, 1000.0f, 0.0f);
 
     /** Array of timer handles for pending destroy operations */
     TArray<FTimerHandle> PendingDestroyTimers;


### PR DESCRIPTION
Levels were always spawning at hardcoded origin FVector(0, 1000, 0) regardless of player respawn location, causing the character to fall endlessly through empty space. Also fixes race condition where gravity applied between teleport and level rebuild.

- Make SpawnInitialLevels() position-aware with player Y coordinate
- Store FirstLevelSpawnPosition for SpawnLevel(true) to use
- Add GetWorld() null guard and GetPlayerPawn() fallback to TryAcquirePlayerPawn()
- Fix Tick() recovery path to also use player position
- Disable gravity/movement before teleport, restore after level spawn
- Add *.bak to .gitignore