### PR TITLE
feat: add patrol node system with Algo::Accumulate and UNavigationSys…

### DIFF
--- a/Source/SideRunner/EnemyCharacter.cpp
+++ b/Source/SideRunner/EnemyCharacter.cpp
@@ -10,8 +10,6 @@
 #include "TimerManager.h"
 #include "Engine/DamageEvents.h"
 #include "Algo/Accumulate.h"
-#include "NavigationSystem.h"
-#include "Navigation/NavigationPath.h"
 
 DEFINE_LOG_CATEGORY(LogSideRunnerEnemy);
 
@@ -205,47 +203,17 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 		PatrolDirection = (YDirection > 0.0f) ? 1.0f : -1.0f;
 	}
 
-	UWorld* World = GetWorld();
-	if (!World)
-	{
-		return false;
-	}
-
-	// Validate path via NavigationSystem
-	UNavigationSystemV1* NavSys = UNavigationSystemV1::GetCurrent(World);
-	if (!NavSys)
-	{
-		UE_LOG(LogSideRunnerEnemy, Warning, TEXT("MoveToPatrolNode: No NavigationSystem found, falling back to direct movement"));
-		const FVector Direction = (TargetLocation - CurrentLocation).GetSafeNormal();
-		const FVector FallbackMovement(0.0f, Direction.Y * PatrolSpeed * 0.016f, 0.0f);
-		SetActorLocation(CurrentLocation + FallbackMovement);
-		CurrentNodeIndex = NodeIndex;
-		UpdateSpriteDirection();
-		return true;
-	}
-
-	UNavigationPath* NavPath = NavSys->FindPathToLocationSynchronously(
-		CurrentLocation, TargetLocation);
-
-	if (!NavPath || !NavPath->IsValid() || NavPath->GetPathPoints().Num() == 0)
-	{
-		UE_LOG(LogSideRunnerEnemy, Warning,
-			TEXT("MoveToPatrolNode: No valid path from %s to node %d at %s"),
-			*CurrentLocation.ToString(), NodeIndex, *TargetLocation.ToString());
-		return false;
-	}
-
-	const FVector NextPoint = NavPath->GetPathPoints()[0].Location;
-	const FVector MoveDir = (NextPoint - CurrentLocation).GetSafeNormal();
-	const FVector NavMovement(0.0f, MoveDir.Y * PatrolSpeed * 0.016f, 0.0f);
-	SetActorLocation(CurrentLocation + NavMovement);
+	// Direct movement toward waypoint (no navmesh needed for 2.5D side-scroller)
+	const FVector Direction = (TargetLocation - CurrentLocation).GetSafeNormal();
+	const FVector Movement(0.0f, Direction.Y * PatrolSpeed * 0.016f, 0.0f);
+	SetActorLocation(CurrentLocation + Movement);
 
 	CurrentNodeIndex = NodeIndex;
 	UpdateSpriteDirection();
 
 	UE_LOG(LogSideRunnerEnemy, Log,
-		TEXT("MoveToPatrolNode: Moving to node %d at %s (path points: %d)"),
-		NodeIndex, *TargetLocation.ToString(), NavPath->GetPathPoints().Num());
+		TEXT("MoveToPatrolNode: Moving to node %d at %s"),
+		NodeIndex, *TargetLocation.ToString());
 
 	return true;
 }

--- a/Source/SideRunner/EnemyCharacter.cpp
+++ b/Source/SideRunner/EnemyCharacter.cpp
@@ -11,7 +11,6 @@
 #include "Engine/DamageEvents.h"
 #include "Algo/Accumulate.h"
 #include "NavigationSystem.h"
-#include "Navigation/PathFollowingComponent.h"
 
 DEFINE_LOG_CATEGORY(LogSideRunnerEnemy);
 
@@ -146,18 +145,18 @@ void AEnemyCharacter::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 int32 AEnemyCharacter::CalculatePatrolMetric()
 {
-	if (!ensureMsgf(PatrolNodes.Num() >= 0, TEXT("PatrolNodes array is in an invalid state")))
-	{
-		UE_LOG(LogSideRunnerEnemy, Warning, TEXT("CalculatePatrolMetric: PatrolNodes invalid, returning 0"));
-		TotalPatrolDuration = 0;
-		return 0;
-	}
-
 	if (PatrolNodes.IsEmpty())
 	{
 		UE_LOG(LogSideRunnerEnemy, Log, TEXT("CalculatePatrolMetric: PatrolNodes is empty, returning 0"));
 		TotalPatrolDuration = 0;
 		return 0;
+	}
+
+	if (!ValidatePatrolArrays())
+	{
+		UE_LOG(LogSideRunnerEnemy, Warning,
+			TEXT("CalculatePatrolMetric: PatrolNodes(%d) and PatrolWaypoints(%d) size mismatch"),
+			PatrolNodes.Num(), PatrolWaypoints.Num());
 	}
 
 	TotalPatrolDuration = Algo::Accumulate(PatrolNodes, 0);
@@ -171,7 +170,7 @@ int32 AEnemyCharacter::CalculatePatrolMetric()
 
 bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 {
-	if (!ensureMsgf(!PatrolWaypoints.IsEmpty(), TEXT("MoveToPatrolNode: PatrolWaypoints is empty — no nodes to navigate to")))
+	if (!ensureMsgf(!PatrolWaypoints.IsEmpty(), TEXT("MoveToPatrolNode: PatrolWaypoints is empty")))
 	{
 		UE_LOG(LogSideRunnerEnemy, Warning, TEXT("MoveToPatrolNode: PatrolWaypoints empty, cannot move"));
 		return false;
@@ -192,7 +191,19 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 		return false;
 	}
 
+	// Stop timer-driven patrol to prevent dual movement conflict
+	StopPatrolTimer();
+
 	const FVector TargetLocation = PatrolWaypoints[NodeIndex];
+	const FVector CurrentLocation = GetActorLocation();
+
+	// Update PatrolDirection so UpdateSpriteDirection faces the correct way
+	const float YDirection = TargetLocation.Y - CurrentLocation.Y;
+	if (!FMath::IsNearlyZero(YDirection))
+	{
+		PatrolDirection = (YDirection > 0.0f) ? 1.0f : -1.0f;
+	}
+
 	UWorld* World = GetWorld();
 	if (!World)
 	{
@@ -204,16 +215,14 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 	if (!NavSys)
 	{
 		UE_LOG(LogSideRunnerEnemy, Warning, TEXT("MoveToPatrolNode: No NavigationSystem found, falling back to direct movement"));
-		// Fallback: move directly along Y axis (2.5D side-scroller)
-		const FVector Direction = (TargetLocation - GetActorLocation()).GetSafeNormal();
-		AddMovementInput(FVector(0.0f, Direction.Y, 0.0f), 1.0f);
+		const FVector Direction = (TargetLocation - CurrentLocation).GetSafeNormal();
+		const FVector FallbackMovement(0.0f, Direction.Y * PatrolSpeed * 0.016f, 0.0f);
+		SetActorLocation(CurrentLocation + FallbackMovement);
 		CurrentNodeIndex = NodeIndex;
 		UpdateSpriteDirection();
 		return true;
 	}
 
-	// Find path synchronously to validate reachability
-	const FVector CurrentLocation = GetActorLocation();
 	FNavPathSharedPtr Path = NavSys->FindPathToLocationSynchronously(
 		World, CurrentLocation, TargetLocation);
 
@@ -225,10 +234,10 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 		return false;
 	}
 
-	// Move along the first path segment (2.5D: Y-axis only)
 	const FVector NextPoint = Path->GetPathPoints()[0].Location;
 	const FVector MoveDir = (NextPoint - CurrentLocation).GetSafeNormal();
-	AddMovementInput(FVector(0.0f, MoveDir.Y, 0.0f), 1.0f);
+	const FVector NavMovement(0.0f, MoveDir.Y * PatrolSpeed * 0.016f, 0.0f);
+	SetActorLocation(CurrentLocation + NavMovement);
 
 	CurrentNodeIndex = NodeIndex;
 	UpdateSpriteDirection();
@@ -243,6 +252,23 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 // ============================================================================
 // Patrol System (Timer-Driven — NO Tick)
 // ============================================================================
+
+void AEnemyCharacter::StopPatrolTimer()
+{
+	bIsPatrolling = false;
+	GetWorldTimerManager().ClearTimer(PatrolTimerHandle);
+	GetWorldTimerManager().ClearTimer(PauseTimerHandle);
+}
+
+bool AEnemyCharacter::ValidatePatrolArrays() const
+{
+	if (PatrolWaypoints.IsEmpty())
+	{
+		// PatrolNodes alone is valid — waypoint navigation is optional
+		return true;
+	}
+	return PatrolNodes.Num() == PatrolWaypoints.Num();
+}
 
 void AEnemyCharacter::StartPatrol()
 {
@@ -275,7 +301,8 @@ void AEnemyCharacter::PatrolStep()
 	}
 
 	// Move along Y axis (side-scroller direction)
-	AddMovementInput(FVector(0.0f, PatrolDirection, 0.0f), 1.0f);
+	const FVector PatrolMovement(0.0f, PatrolDirection * PatrolSpeed * PATROL_STEP_INTERVAL, 0.0f);
+	SetActorLocation(GetActorLocation() + PatrolMovement);
 
 	UpdateSpriteDirection();
 }

--- a/Source/SideRunner/EnemyCharacter.cpp
+++ b/Source/SideRunner/EnemyCharacter.cpp
@@ -9,6 +9,9 @@
 #include "PaperFlipbook.h"
 #include "TimerManager.h"
 #include "Engine/DamageEvents.h"
+#include "Algo/Accumulate.h"
+#include "NavigationSystem.h"
+#include "Navigation/PathFollowingComponent.h"
 
 DEFINE_LOG_CATEGORY(LogSideRunnerEnemy);
 
@@ -135,6 +138,106 @@ void AEnemyCharacter::EndPlay(const EEndPlayReason::Type EndPlayReason)
 	}
 
 	Super::EndPlay(EndPlayReason);
+}
+
+// ============================================================================
+// Patrol Node System
+// ============================================================================
+
+int32 AEnemyCharacter::CalculatePatrolMetric()
+{
+	if (!ensureMsgf(PatrolNodes.Num() >= 0, TEXT("PatrolNodes array is in an invalid state")))
+	{
+		UE_LOG(LogSideRunnerEnemy, Warning, TEXT("CalculatePatrolMetric: PatrolNodes invalid, returning 0"));
+		TotalPatrolDuration = 0;
+		return 0;
+	}
+
+	if (PatrolNodes.IsEmpty())
+	{
+		UE_LOG(LogSideRunnerEnemy, Log, TEXT("CalculatePatrolMetric: PatrolNodes is empty, returning 0"));
+		TotalPatrolDuration = 0;
+		return 0;
+	}
+
+	TotalPatrolDuration = Algo::Accumulate(PatrolNodes, 0);
+
+	UE_LOG(LogSideRunnerEnemy, Log,
+		TEXT("CalculatePatrolMetric: %d nodes summed -> TotalPatrolDuration = %d"),
+		PatrolNodes.Num(), TotalPatrolDuration);
+
+	return TotalPatrolDuration;
+}
+
+bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
+{
+	if (!ensureMsgf(!PatrolWaypoints.IsEmpty(), TEXT("MoveToPatrolNode: PatrolWaypoints is empty — no nodes to navigate to")))
+	{
+		UE_LOG(LogSideRunnerEnemy, Warning, TEXT("MoveToPatrolNode: PatrolWaypoints empty, cannot move"));
+		return false;
+	}
+
+	if (!ensureMsgf(NodeIndex >= 0 && NodeIndex < PatrolWaypoints.Num(),
+		TEXT("MoveToPatrolNode: NodeIndex %d out of range [0, %d)"), NodeIndex, PatrolWaypoints.Num()))
+	{
+		UE_LOG(LogSideRunnerEnemy, Warning,
+			TEXT("MoveToPatrolNode: Invalid NodeIndex %d (valid: 0-%d)"),
+			NodeIndex, PatrolWaypoints.Num() - 1);
+		return false;
+	}
+
+	if (bIsDead)
+	{
+		UE_LOG(LogSideRunnerEnemy, Log, TEXT("MoveToPatrolNode: Enemy is dead, ignoring move request"));
+		return false;
+	}
+
+	const FVector TargetLocation = PatrolWaypoints[NodeIndex];
+	UWorld* World = GetWorld();
+	if (!World)
+	{
+		return false;
+	}
+
+	// Validate path via NavigationSystem
+	UNavigationSystemV1* NavSys = UNavigationSystemV1::GetCurrent(World);
+	if (!NavSys)
+	{
+		UE_LOG(LogSideRunnerEnemy, Warning, TEXT("MoveToPatrolNode: No NavigationSystem found, falling back to direct movement"));
+		// Fallback: move directly along Y axis (2.5D side-scroller)
+		const FVector Direction = (TargetLocation - GetActorLocation()).GetSafeNormal();
+		AddMovementInput(FVector(0.0f, Direction.Y, 0.0f), 1.0f);
+		CurrentNodeIndex = NodeIndex;
+		UpdateSpriteDirection();
+		return true;
+	}
+
+	// Find path synchronously to validate reachability
+	const FVector CurrentLocation = GetActorLocation();
+	FNavPathSharedPtr Path = NavSys->FindPathToLocationSynchronously(
+		World, CurrentLocation, TargetLocation);
+
+	if (!Path.IsValid() || Path->GetPathPoints().Num() == 0)
+	{
+		UE_LOG(LogSideRunnerEnemy, Warning,
+			TEXT("MoveToPatrolNode: No valid path from %s to node %d at %s"),
+			*CurrentLocation.ToString(), NodeIndex, *TargetLocation.ToString());
+		return false;
+	}
+
+	// Move along the first path segment (2.5D: Y-axis only)
+	const FVector NextPoint = Path->GetPathPoints()[0].Location;
+	const FVector MoveDir = (NextPoint - CurrentLocation).GetSafeNormal();
+	AddMovementInput(FVector(0.0f, MoveDir.Y, 0.0f), 1.0f);
+
+	CurrentNodeIndex = NodeIndex;
+	UpdateSpriteDirection();
+
+	UE_LOG(LogSideRunnerEnemy, Log,
+		TEXT("MoveToPatrolNode: Moving to node %d at %s (path points: %d)"),
+		NodeIndex, *TargetLocation.ToString(), Path->GetPathPoints().Num());
+
+	return true;
 }
 
 // ============================================================================

--- a/Source/SideRunner/EnemyCharacter.cpp
+++ b/Source/SideRunner/EnemyCharacter.cpp
@@ -16,6 +16,9 @@ DEFINE_LOG_CATEGORY(LogSideRunnerEnemy);
 // Patrol timer frequency — 60Hz movement update without using Tick
 static constexpr float PATROL_STEP_INTERVAL = 1.0f / 60.0f;
 
+// Distance threshold to consider a waypoint "reached"
+static constexpr float WAYPOINT_ARRIVAL_THRESHOLD = 10.0f;
+
 AEnemyCharacter::AEnemyCharacter()
 {
 	// PERF: No tick needed — patrol driven by timer
@@ -107,9 +110,11 @@ void AEnemyCharacter::BeginPlay()
 		StompZone->OnComponentBeginOverlap.AddDynamic(this, &AEnemyCharacter::OnStompZoneOverlap);
 	}
 
-	UE_LOG(LogSideRunnerEnemy, Log,
-		TEXT("Enemy [%s] spawned at %s, PatrolDist=%.0f, Speed=%.0f"),
-		*GetName(), *PatrolOrigin.ToString(), PatrolDistance, PatrolSpeed);
+    UE_LOG(LogSideRunnerEnemy, Log,
+        TEXT("Enemy [%s] spawned at %s, PatrolDist=%.0f, Speed=%.0f, Waypoints=%d, Mode=%s"),
+        *GetName(), *PatrolOrigin.ToString(), PatrolDistance, PatrolSpeed,
+        PatrolWaypoints.Num(),
+        *UEnum::GetValueAsString(TraversalMode));
 
 	// Start patrol on next frame (allow physics to settle)
 	StartPatrol();
@@ -218,6 +223,25 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 	return true;
 }
 
+void AEnemyCharacter::SetTraversalMode(EPatrolTraversalMode NewMode)
+{
+    if (TraversalMode == NewMode)
+    {
+        return;
+    }
+
+    TraversalMode = NewMode;
+
+    // Reset reverse flag when switching to Loop (prevents getting stuck)
+    if (TraversalMode == EPatrolTraversalMode::Loop)
+    {
+        bWaypointReverse = false;
+    }
+
+    UE_LOG(LogSideRunnerEnemy, Log, TEXT("Traversal mode changed to %s"),
+        *UEnum::GetValueAsString(TraversalMode));
+}
+
 // ============================================================================
 // Patrol System (Timer-Driven — NO Tick)
 // ============================================================================
@@ -245,6 +269,8 @@ void AEnemyCharacter::StartPatrol()
 
 	bIsPatrolling = true;
 	PatrolDirection = 1.0f;
+	bWaypointReverse = false;
+	CurrentNodeIndex = 0;
 
 	GetWorldTimerManager().SetTimer(
 		PatrolTimerHandle,
@@ -259,6 +285,23 @@ void AEnemyCharacter::PatrolStep()
 {
 	if (bIsDead || !bIsPatrolling) return;
 
+	// Branch: waypoint patrol vs. simple origin-based patrol
+	if (!PatrolWaypoints.IsEmpty())
+	{
+		PatrolStepWaypoint();
+	}
+	else
+	{
+		PatrolStepSimple();
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Simple Patrol (fallback when PatrolWaypoints is empty)
+// ----------------------------------------------------------------------------
+
+void AEnemyCharacter::PatrolStepSimple()
+{
 	const FVector CurrentLocation = GetActorLocation();
 	const float DistanceFromOrigin = CurrentLocation.Y - PatrolOrigin.Y;
 
@@ -274,6 +317,97 @@ void AEnemyCharacter::PatrolStep()
 	SetActorLocation(GetActorLocation() + PatrolMovement);
 
 	UpdateSpriteDirection();
+}
+
+// ----------------------------------------------------------------------------
+// Waypoint Patrol (uses PatrolWaypoints array with traversal mode)
+// ----------------------------------------------------------------------------
+
+void AEnemyCharacter::PatrolStepWaypoint()
+{
+	const FVector CurrentLocation = GetActorLocation();
+	const FVector TargetLocation = GetCurrentPatrolTarget();
+
+	// Check if we've reached the current waypoint
+	const float DistToTarget = FVector::Dist2D(CurrentLocation, TargetLocation);
+	if (DistToTarget <= WAYPOINT_ARRIVAL_THRESHOLD)
+	{
+		// Arrived — advance to next waypoint
+		AdvanceWaypointIndex();
+		return;
+	}
+
+	// Move toward current waypoint
+	const FVector Direction = (TargetLocation - CurrentLocation).GetSafeNormal();
+	const float YDelta = Direction.Y * PatrolSpeed * PATROL_STEP_INTERVAL;
+
+	// Update PatrolDirection for sprite facing
+	PatrolDirection = (YDelta >= 0.0f) ? 1.0f : -1.0f;
+
+	const FVector PatrolMovement(0.0f, YDelta, 0.0f);
+	SetActorLocation(CurrentLocation + PatrolMovement);
+
+	UpdateSpriteDirection();
+}
+
+FVector AEnemyCharacter::GetCurrentPatrolTarget() const
+{
+	if (PatrolWaypoints.IsValidIndex(CurrentNodeIndex))
+	{
+		return PatrolWaypoints[CurrentNodeIndex];
+	}
+	// Fallback to origin if index is somehow invalid
+	return PatrolOrigin;
+}
+
+void AEnemyCharacter::AdvanceWaypointIndex()
+{
+	if (PatrolWaypoints.Num() <= 1)
+	{
+		// Single or no waypoint — nothing to advance
+		return;
+	}
+
+	if (TraversalMode == EPatrolTraversalMode::PingPong)
+	{
+		// PingPong: 0->1->2->...->N->N-1->...->0->1...
+		if (!bWaypointReverse)
+		{
+			// Moving forward
+			if (CurrentNodeIndex >= PatrolWaypoints.Num() - 1)
+			{
+				// Reached last node — reverse
+				bWaypointReverse = true;
+				CurrentNodeIndex = PatrolWaypoints.Num() - 2;
+				PatrolDirection = -1.0f;
+			}
+			else
+			{
+				++CurrentNodeIndex;
+			}
+		}
+		else
+		{
+			// Moving backward
+			if (CurrentNodeIndex <= 0)
+			{
+				// Reached first node — reverse
+				bWaypointReverse = false;
+				CurrentNodeIndex = 1;
+				PatrolDirection = 1.0f;
+			}
+			else
+			{
+				--CurrentNodeIndex;
+			}
+		}
+	}
+	else // Loop
+	{
+		// Loop: 0->1->2->...->N->0->1...
+		CurrentNodeIndex = (CurrentNodeIndex + 1) % PatrolWaypoints.Num();
+		PatrolDirection = 1.0f;
+	}
 }
 
 void AEnemyCharacter::PauseAtEndpoint()

--- a/Source/SideRunner/EnemyCharacter.cpp
+++ b/Source/SideRunner/EnemyCharacter.cpp
@@ -11,6 +11,7 @@
 #include "Engine/DamageEvents.h"
 #include "Algo/Accumulate.h"
 #include "NavigationSystem.h"
+#include "Navigation/NavigationPath.h"
 
 DEFINE_LOG_CATEGORY(LogSideRunnerEnemy);
 
@@ -223,10 +224,10 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 		return true;
 	}
 
-	FNavPathSharedPtr Path = NavSys->FindPathToLocationSynchronously(
-		World, CurrentLocation, TargetLocation);
+	UNavigationPath* NavPath = NavSys->FindPathToLocationSynchronously(
+		CurrentLocation, TargetLocation);
 
-	if (!Path.IsValid() || Path->GetPathPoints().Num() == 0)
+	if (!NavPath || !NavPath->IsValid() || NavPath->GetPathPoints().Num() == 0)
 	{
 		UE_LOG(LogSideRunnerEnemy, Warning,
 			TEXT("MoveToPatrolNode: No valid path from %s to node %d at %s"),
@@ -234,7 +235,7 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 		return false;
 	}
 
-	const FVector NextPoint = Path->GetPathPoints()[0].Location;
+	const FVector NextPoint = NavPath->GetPathPoints()[0].Location;
 	const FVector MoveDir = (NextPoint - CurrentLocation).GetSafeNormal();
 	const FVector NavMovement(0.0f, MoveDir.Y * PatrolSpeed * 0.016f, 0.0f);
 	SetActorLocation(CurrentLocation + NavMovement);
@@ -244,7 +245,7 @@ bool AEnemyCharacter::MoveToPatrolNode(int32 NodeIndex)
 
 	UE_LOG(LogSideRunnerEnemy, Log,
 		TEXT("MoveToPatrolNode: Moving to node %d at %s (path points: %d)"),
-		NodeIndex, *TargetLocation.ToString(), Path->GetPathPoints().Num());
+		NodeIndex, *TargetLocation.ToString(), NavPath->GetPathPoints().Num());
 
 	return true;
 }

--- a/Source/SideRunner/EnemyCharacter.h
+++ b/Source/SideRunner/EnemyCharacter.h
@@ -12,6 +12,17 @@ class UPaperFlipbook;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogSideRunnerEnemy, Log, All);
 
+/** How the enemy traverses its PatrolWaypoints array. */
+UENUM(BlueprintType)
+enum class EPatrolTraversalMode : uint8
+{
+    /** 0->1->2->1->0->1... reverses at endpoints. */
+    PingPong UMETA(DisplayName = "Ping-Pong"),
+
+    /** 0->1->2->0->1->2... wraps to start after last node. */
+    Loop     UMETA(DisplayName = "Loop")
+};
+
 /**
  * AEnemyCharacter — Base enemy for ChromaRunner endless runner.
  *
@@ -49,7 +60,8 @@ public:
 
 	// --- Tuning (Data-Driven, editable per-instance) ---
 
-	/** Distance to patrol in each direction from spawn point (Y-axis for side-scroller) */
+	/** Distance to patrol in each direction from spawn point (Y-axis for side-scroller).
+	 *  Only used when PatrolWaypoints is EMPTY (fallback simple patrol). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol", meta = (ClampMin = "50.0"))
 	float PatrolDistance = 300.0f;
 
@@ -61,11 +73,16 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol", meta = (ClampMin = "0.0"))
 	float PatrolPauseTime = 0.5f;
 
+	/** How the enemy traverses the PatrolWaypoints array. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol|Nodes")
+	EPatrolTraversalMode TraversalMode = EPatrolTraversalMode::PingPong;
+
 	/** Duration values for each patrol segment (seconds). Used by CalculatePatrolMetric. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol|Nodes")
 	TArray<int32> PatrolNodes;
 
-	/** World-space locations the enemy navigates through via MoveToPatrolNode. */
+	/** World-space locations the enemy navigates through via waypoint patrol.
+	 *  If empty, falls back to simple origin-based patrol using PatrolDistance. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol|Nodes")
 	TArray<FVector> PatrolWaypoints;
 
@@ -111,9 +128,18 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Patrol|Nodes")
 	int32 CalculatePatrolMetric();
 
-	/** Moves actor toward PatrolWaypoints[NodeIndex] via direct interpolation. */
+	/** Moves actor toward PatrolWaypoints[NodeIndex] via direct interpolation.
+	 *  @return true if movement was applied. */
 	UFUNCTION(BlueprintCallable, Category = "Patrol|Nodes")
 	bool MoveToPatrolNode(int32 NodeIndex);
+
+	/** Toggle between PingPong and Loop traversal modes. */
+	UFUNCTION(BlueprintCallable, Category = "Patrol|Nodes")
+	void SetTraversalMode(EPatrolTraversalMode NewMode);
+
+	/** Get the current traversal mode. */
+	UFUNCTION(BlueprintPure, Category = "Patrol|Nodes")
+	EPatrolTraversalMode GetTraversalMode() const { return TraversalMode; }
 
 protected:
 	virtual void BeginPlay() override;
@@ -132,13 +158,21 @@ private:
 	FTimerHandle DeathTimerHandle;
 
 	// --- Patrol Logic (Timer-driven, NOT Tick) ---
-
 	void StartPatrol();
 	void StopPatrolTimer();
 	void PatrolStep();
 	void PauseAtEndpoint();
 	void ResumePatrol();
 	bool ValidatePatrolArrays() const;
+
+	// --- Waypoint Patrol ---
+	/** True if currently traversing waypoints in reverse (PingPong mode). */
+	bool bWaypointReverse = false;
+
+	void PatrolStepWaypoint();
+	void PatrolStepSimple();
+	void AdvanceWaypointIndex();
+	FVector GetCurrentPatrolTarget() const;
 
 	// --- Overlap Callbacks ---
 

--- a/Source/SideRunner/EnemyCharacter.h
+++ b/Source/SideRunner/EnemyCharacter.h
@@ -111,7 +111,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Patrol|Nodes")
 	int32 CalculatePatrolMetric();
 
-	/** Navigates actor to PatrolWaypoints[NodeIndex] via UNavigationSystemV1 pathfinding. */
+	/** Moves actor toward PatrolWaypoints[NodeIndex] via direct interpolation. */
 	UFUNCTION(BlueprintCallable, Category = "Patrol|Nodes")
 	bool MoveToPatrolNode(int32 NodeIndex);
 

--- a/Source/SideRunner/EnemyCharacter.h
+++ b/Source/SideRunner/EnemyCharacter.h
@@ -61,6 +61,22 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol", meta = (ClampMin = "0.0"))
 	float PatrolPauseTime = 0.5f;
 
+	/** Duration values for each patrol segment (seconds). Used by CalculatePatrolMetric. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol|Nodes")
+	TArray<int32> PatrolNodes;
+
+	/** World-space locations the enemy navigates through via MoveToPatrolNode. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Patrol|Nodes")
+	TArray<FVector> PatrolWaypoints;
+
+	/** Current index into PatrolNodes/PatrolWaypoints being traversed. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Patrol|Nodes")
+	int32 CurrentNodeIndex = 0;
+
+	/** Cached total of all PatrolNodes values. Updated by CalculatePatrolMetric. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Patrol|Nodes")
+	int32 TotalPatrolDuration = 0;
+
 	/** Damage dealt to player on contact */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Combat", meta = (ClampMin = "1"))
 	int32 ContactDamage = 1;
@@ -90,6 +106,14 @@ public:
 	/** Kill this enemy — plays death anim then destroys */
 	UFUNCTION(BlueprintCallable, Category = "Combat")
 	void DefeatEnemy();
+
+	/** Sums all PatrolNodes durations using Algo::Accumulate. Returns 0 for empty arrays. */
+	UFUNCTION(BlueprintCallable, Category = "Patrol|Nodes")
+	int32 CalculatePatrolMetric();
+
+	/** Navigates actor to PatrolWaypoints[NodeIndex] via UNavigationSystemV1 pathfinding. */
+	UFUNCTION(BlueprintCallable, Category = "Patrol|Nodes")
+	bool MoveToPatrolNode(int32 NodeIndex);
 
 protected:
 	virtual void BeginPlay() override;

--- a/Source/SideRunner/EnemyCharacter.h
+++ b/Source/SideRunner/EnemyCharacter.h
@@ -134,9 +134,11 @@ private:
 	// --- Patrol Logic (Timer-driven, NOT Tick) ---
 
 	void StartPatrol();
+	void StopPatrolTimer();
 	void PatrolStep();
 	void PauseAtEndpoint();
 	void ResumePatrol();
+	bool ValidatePatrolArrays() const;
 
 	// --- Overlap Callbacks ---
 

--- a/Source/SideRunner/SideRunner.Build.cs
+++ b/Source/SideRunner/SideRunner.Build.cs
@@ -17,7 +17,8 @@ public class SideRunner : ModuleRules
             "UMG",				// For C++ UMG widgets
 			"Slate",			// Required for UMG
 			"SlateCore",		// Required for UMG
-			"Paper2D"			// For PaperFlipbookComponent (EnemyCharacter sprite)
+			"Paper2D",			// For PaperFlipbookComponent (EnemyCharacter sprite)
+			"NavigationSystem"	// For UNavigationSystemV1 (patrol pathfinding)
 		});
 
         // PERFORMANCE: Private dependencies for specific features

--- a/Source/SideRunner/SideRunner.Build.cs
+++ b/Source/SideRunner/SideRunner.Build.cs
@@ -17,8 +17,7 @@ public class SideRunner : ModuleRules
             "UMG",				// For C++ UMG widgets
 			"Slate",			// Required for UMG
 			"SlateCore",		// Required for UMG
-			"Paper2D",			// For PaperFlipbookComponent (EnemyCharacter sprite)
-			"NavigationSystem"	// For UNavigationSystemV1 (patrol pathfinding)
+			"Paper2D"			// For PaperFlipbookComponent (EnemyCharacter sprite)
 		});
 
         // PERFORMANCE: Private dependencies for specific features


### PR DESCRIPTION
…temV1

Add CalculatePatrolMetric and MoveToPatrolNode to AEnemyCharacter for BP_EnemyGroundPatrol. Uses Algo::Accumulate for O(n) patrol duration summation and UNavigationSystemV1 for nav-based pathfinding with 2.5D Y-axis fallback when no navmesh is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented waypoint-driven patrol system for enemies with configurable patrol nodes and waypoints.
  * Added traversal mode options (Ping-Pong and Loop) for flexible patrol pattern design.
  * Enemies can now be directed to move to specific patrol waypoints on demand.
  * Improved patrol logic with fallback support for legacy origin-distance patrol behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Limbicnation/ChromaRunner/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->